### PR TITLE
Add manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ requirements = read("requirements.txt").split()
 
 setup(
     name="cleaning-scripts",
-    version="0.2.0",
+    version="0.2.3",
     author="Arkhn",
     author_email="contact@arkhn.org",
     description="Python scripts used in the FHIR integration pipeline "


### PR DESCRIPTION
When uploading with Twine, the `requirements.txt` file was missing in the package.
This should solve the problem.