### PR TITLE
Can use get_script on logic scripts

### DIFF
--- a/scripts/get_script.py
+++ b/scripts/get_script.py
@@ -11,6 +11,8 @@ def get_script(name):
         return getattr(custom, name)
     elif name in utils.__all__:
         return getattr(utils, name)
+    elif name in logic.__all__:
+        return getattr(logic, name)
     else:
         if name.startswith("if_valid("):
             # get args part between (  )

--- a/scripts/logic/__init__.py
+++ b/scripts/logic/__init__.py
@@ -1,2 +1,16 @@
 """Scripts for implementing logic"""
 from .if_valid import if_valid  # noqa
+import pkgutil
+import inspect
+
+__all__ = []
+
+for loader, name, is_pkg in pkgutil.walk_packages(__path__):
+    module = loader.find_module(name).load_module(name)
+
+    for name, value in inspect.getmembers(module):
+        if name.startswith("__"):
+            continue
+
+        globals()[name] = value
+        __all__.append(name)

--- a/scripts/utils/is_empty.py
+++ b/scripts/utils/is_empty.py
@@ -3,6 +3,7 @@ def is_empty(value):
     return (
         value is None
         or value == "NaN"
+        or value == "NaT"
         or value == "None"
         or value == ""
         or value in "                        "

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ requirements = read("requirements.txt").split()
 
 setup(
     name="cleaning-scripts",
-    version="0.2.11",
+    version="0.2.12",
     author="Arkhn",
     author_email="contact@arkhn.org",
     description="Python scripts used in the FHIR integration pipeline "


### PR DESCRIPTION
When logic scripts where used in mapping, fhirpipe couldn't find them

I also added a case in is_empty ("NaT")