### PR TITLE
Remove useless dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,6 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-requirements = read("requirements.txt").split()
-
 setup(
     name="cleaning-scripts",
     version="0.2.27",
@@ -20,5 +18,4 @@ setup(
     packages=find_packages(exclude=["api*", "test*"]),
     long_description=read("README.md"),
     long_description_content_type="text/markdown",
-    install_requires=requirements,
 )

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,8 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
+extras_require = {"test": ["pytest"], "dev": []}
+
 setup(
     name="cleaning-scripts",
     version="0.2.28",
@@ -18,4 +20,5 @@ setup(
     packages=find_packages(exclude=["api*", "test*"]),
     long_description=read("README.md"),
     long_description_content_type="text/markdown",
+    extras_require=extras_require,
 )

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(fname):
 
 setup(
     name="cleaning-scripts",
-    version="0.2.27",
+    version="0.2.28",
     author="Arkhn",
     author_email="contact@arkhn.org",
     description="Python scripts used in the FHIR integration pipeline "

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py38
+skipsdist = true
+
+[testenv]
+deps = .[test]
+commands =
+    pip install -e .
+    pytest


### PR DESCRIPTION
## Fixes
Closes #53 

## Description
See #53 
To declare future **actual** dependencies, declare them in `setup.py` with `setup(..., install_requires={},...)`.
Add tox to run tests in reproductible env.

## Tests
- [x] Verify that tests run without these dependencies
