### PR TITLE
Use .isoformat() to format dateTime

### DIFF
--- a/scripts/custom/clean_date.py
+++ b/scripts/custom/clean_date.py
@@ -46,4 +46,5 @@ def clean_date(raw_input):  # noqa: C901
     if date is None:
         return raw_input
 
-    return date.strftime("%Y-%m-%d")
+    # We only want the date
+    return date.isoformat().split("T")[0]

--- a/scripts/custom/clean_dateTime.py
+++ b/scripts/custom/clean_dateTime.py
@@ -33,35 +33,35 @@ def clean_dateTime(raw_input):  # noqa: C901
     # Handle YYYY
     try:
         date = datetime.datetime.strptime(raw_input, "%Y")
-        result = date.strftime("%Y")
+        result = date.isoformat().split("-")[0]
     except ValueError:
         pass
 
     # Handle YYYY-MM
     try:
         date = datetime.datetime.strptime(raw_input, "%Y-%m")
-        result = date.strftime("%Y-%m")
+        result = date.isoformat()[:7]
     except ValueError:
         pass
 
     # Handle YYYYMM
     try:
         date = datetime.datetime.strptime(raw_input, "%Y%m")
-        result = date.strftime("%Y-%m")
+        result = date.isoformat()[:7]
     except ValueError:
         pass
 
     # Handle YYYY-MM-DD
     try:
         date = datetime.datetime.strptime(raw_input, "%Y-%m-%d")
-        result = date.strftime("%Y-%m-%d")
+        result = date.isoformat().split("T")[0]
     except ValueError:
         pass
 
     # Handle YYYYMMDD
     try:
         date = datetime.datetime.strptime(raw_input, "%Y%m%d")
-        result = date.strftime("%Y-%m-%d")
+        result = date.isoformat().split("T")[0]
     except ValueError:
         pass
 

--- a/scripts/custom/clean_dateTime.py
+++ b/scripts/custom/clean_dateTime.py
@@ -4,6 +4,11 @@ import re
 from scripts import utils
 
 
+def add_default_timezone(date):
+    # By default, we set the timezone to UTC+2 (Paris)... Until we expand worldwide!
+    return date.replace(tzinfo=datetime.timezone(datetime.timedelta(hours=2)))
+
+
 def clean_dateTime(raw_input):  # noqa: C901
     if not isinstance(raw_input, str):
         raw_input = str(raw_input)
@@ -63,42 +68,46 @@ def clean_dateTime(raw_input):  # noqa: C901
     # Handle YYYYMMDDHHMM
     try:
         date = datetime.datetime.strptime(raw_input, "%Y%m%d%H%M")
-        result = date.strftime("%Y-%m-%dT%H:%M:%S+02:00")
+        date_with_tz = add_default_timezone(date)
+        result = date_with_tz.isoformat()
     except ValueError:
         pass
 
     # Handle YYYY-MM-DD H:M:S
     try:
         date = datetime.datetime.strptime(raw_input, "%Y-%m-%d %H:%M:%S")
-        result = date.strftime("%Y-%m-%dT%H:%M:%S+02:00")
+        date_with_tz = add_default_timezone(date)
+        result = date_with_tz.isoformat()
     except ValueError:
         pass
 
     # Handle YYYY-MM-DDTH:M:S
     try:
         date = datetime.datetime.strptime(raw_input, "%Y-%m-%dT%H:%M:%S")
-        result = date.strftime("%Y-%m-%dT%H:%M:%S+02:00")
+        date_with_tz = add_default_timezone(date)
+        result = date_with_tz.isoformat()
     except ValueError:
         pass
 
     # Handle YYYY-MM-DDTH:M:S+zz:zz
     try:
         date = datetime.datetime.strptime(raw_input, "%Y-%m-%dT%H:%M:%S+%z")
-        result = date.strftime("%Y-%m-%dT%H:%M:%S%z")
+        result = date.isoformat()
     except ValueError:
         pass
 
     # Handle YYYY-MM-DDTH:M:S-zz:zz
     try:
         date = datetime.datetime.strptime(raw_input, "%Y-%m-%dT%H:%M:%S-%z")
-        result = date.strftime("%Y-%m-%dT%H:%M:%S%z")
+        result = date.isoformat()
     except ValueError:
         pass
 
     # Handle RFC 1123 format
     try:
         date = datetime.datetime.strptime(raw_input, "%a, %d %b %Y %H:%M:%S GMT")
-        result = date.strftime("%Y-%m-%dT%H:%M:%S+00:00")
+        date_with_tz = date.replace(tzinfo=datetime.timezone(datetime.timedelta(hours=0)))
+        result = date_with_tz.isoformat()
 
     except ValueError:
         pass

--- a/scripts/custom/clean_instant.py
+++ b/scripts/custom/clean_instant.py
@@ -23,29 +23,32 @@ def clean_instant(raw_input):  # noqa: C901
     for fmt in formats:
         try:
             date = datetime.datetime.strptime(raw_input, fmt)
-            result = date.strftime("%Y-%m-%dT%H:%M:%S+02:00")
-
+            # By default, we set the timezone to UTC+2 (Paris)... Until we expand worldwide!
+            date_with_tz = date.replace(tzinfo=datetime.timezone(datetime.timedelta(hours=2)))
+            result = date_with_tz.isoformat()
+            break
         except ValueError:
             pass
 
     # Handle YYYY-MM-DDTH:M:S+zz:zz
     try:
         date = datetime.datetime.strptime(raw_input, "%Y-%m-%dT%H:%M:%S+%z")
-        result = date.strftime("%Y-%m-%dT%H:%M:%S%z")
+        result = date.isoformat()
     except ValueError:
         pass
 
     # Handle YYYY-MM-DDTH:M:S-zz:zz
     try:
         date = datetime.datetime.strptime(raw_input, "%Y-%m-%dT%H:%M:%S-%z")
-        result = date.strftime("%Y-%m-%dT%H:%M:%S%z")
+        result = date.isoformat()
     except ValueError:
         pass
 
     # Handle RFC 1123 format
     try:
         date = datetime.datetime.strptime(raw_input, "%a, %d %b %Y %H:%M:%S GMT")
-        result = date.strftime("%Y-%m-%dT%H:%M:%S+00:00")
+        date_with_tz = date.replace(tzinfo=datetime.timezone(datetime.timedelta(hours=0)))
+        result = date_with_tz.isoformat()
     except ValueError:
         pass
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ extras_require = {"test": ["pytest"], "dev": []}
 
 setup(
     name="cleaning-scripts",
-    version="0.2.28",
+    version="0.2.29",
     author="Arkhn",
     author_email="contact@arkhn.org",
     description="Python scripts used in the FHIR integration pipeline "

--- a/tests/custom/test_clean_dateTime.py
+++ b/tests/custom/test_clean_dateTime.py
@@ -1,58 +1,26 @@
+import pytest
+
 from scripts.custom import clean_dateTime
 
 
-def test_clean_dateTime():
-    # YYYY format test
-    raw_input_1 = "2015"
-    output_1 = clean_dateTime(raw_input_1)
-    assert output_1 == "2015"
-
-    # YYYY-MM format test
-    raw_input_2 = "2015-02"
-    output_2 = clean_dateTime(raw_input_2)
-    assert output_2 == "2015-02"
-
-    # YYYYMM format test
-    raw_input_3 = "201502"
-    output_3 = clean_dateTime(raw_input_3)
-    assert output_3 == "2015-02"
-
-    # YYYY-MM-DD format test
-    raw_input_4 = "2015-02-07"
-    output_4 = clean_dateTime(raw_input_4)
-    assert output_4 == "2015-02-07"
-
-    # YYYYMMDD format test
-    raw_input_5 = "20150207"
-    output_5 = clean_dateTime(raw_input_5)
-    assert output_5 == "2015-02-07"
-
-    # YYYY-MM-DD H:M:S format test
-    raw_input_6 = "2015-02-07 13:28:17"
-    output_6 = clean_dateTime(raw_input_6)
-    assert output_6 == "2015-02-07T13:28:17+02:00"
-
-    # YYYY-MM-DDTH:M:S format test
-    raw_input_7 = "2015-02-07T13:28:17"
-    output_7 = clean_dateTime(raw_input_7)
-    assert output_7 == "2015-02-07T13:28:17+02:00"
-
-    # YYYY-MM-DDTH:M:S+zz:zz format test
-    raw_input_8 = "2015-02-07T13:28:17+05:00"
-    output_8 = clean_dateTime(raw_input_8)
-    assert output_8 == "2015-02-07T13:28:17+05:00"
-
-    # YYYY-MM-DDTH:M:S-zz:zz format test
-    raw_input_9 = "2015-02-07T13:28:17-05:00"
-    output_9 = clean_dateTime(raw_input_9)
-    assert output_9 == "2015-02-07T13:28:17-05:00"
-
-    # RFC 1123 format test
-    raw_input_10 = "Wed, 13 Mar 2075 00:00:00 GMT"
-    output_10 = clean_dateTime(raw_input_10)
-    assert output_10 == "2075-03-13T00:00:00+00:00"
-
-    # YYYYMMDDHHMM format test
-    raw_input_11 = "201502071740"
-    output_11 = clean_dateTime(raw_input_11)
-    assert output_11 == "2015-02-07T17:40:00+02:00"
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        ("2015", "2015"),
+        ("2015-02", "2015-02"),
+        ("201502", "2015-02"),
+        ("2015-02-07", "2015-02-07"),
+        ("20150207", "2015-02-07"),
+        ("2015-02-07T13:28:17", "2015-02-07T13:28:17+02:00"),
+        ("2015-02-07 13:28:17", "2015-02-07T13:28:17+02:00"),
+        ("2015-02-07T13:28:17+05:00", "2015-02-07T13:28:17+05:00"),
+        ("2015-02-07T13:28:17-05:00", "2015-02-07T13:28:17-05:00"),
+        ("Wed, 13 Mar 2075 00:00:00 GMT", "2075-03-13T00:00:00+00:00"),
+        ("201502071740", "2015-02-07T17:40:00+02:00"),
+        ("", ""),
+        ("0010-04-30", "0010-04-30"),
+    ],
+)
+def test_clean_dateTime(test_input, expected):
+    output = clean_dateTime(test_input)
+    assert output == expected


### PR DESCRIPTION
Otherwise, with Python3.7.9, year `0010` was turned to `10`