### PR TITLE
Remove util function from clean_dateTime script

### DIFF
--- a/scripts/custom/clean_dateTime.py
+++ b/scripts/custom/clean_dateTime.py
@@ -4,11 +4,6 @@ import re
 from scripts import utils
 
 
-def add_default_timezone(date):
-    # By default, we set the timezone to UTC+2 (Paris)... Until we expand worldwide!
-    return date.replace(tzinfo=datetime.timezone(datetime.timedelta(hours=2)))
-
-
 def clean_dateTime(raw_input):  # noqa: C901
     if not isinstance(raw_input, str):
         raw_input = str(raw_input)
@@ -68,7 +63,8 @@ def clean_dateTime(raw_input):  # noqa: C901
     # Handle YYYYMMDDHHMM
     try:
         date = datetime.datetime.strptime(raw_input, "%Y%m%d%H%M")
-        date_with_tz = add_default_timezone(date)
+        # By default, we set the timezone to UTC+2 (Paris)... Until we expand worldwide!
+        date_with_tz = date.replace(tzinfo=datetime.timezone(datetime.timedelta(hours=2)))
         result = date_with_tz.isoformat()
     except ValueError:
         pass
@@ -76,7 +72,8 @@ def clean_dateTime(raw_input):  # noqa: C901
     # Handle YYYY-MM-DD H:M:S
     try:
         date = datetime.datetime.strptime(raw_input, "%Y-%m-%d %H:%M:%S")
-        date_with_tz = add_default_timezone(date)
+        # By default, we set the timezone to UTC+2 (Paris)... Until we expand worldwide!
+        date_with_tz = date.replace(tzinfo=datetime.timezone(datetime.timedelta(hours=2)))
         result = date_with_tz.isoformat()
     except ValueError:
         pass
@@ -84,7 +81,8 @@ def clean_dateTime(raw_input):  # noqa: C901
     # Handle YYYY-MM-DDTH:M:S
     try:
         date = datetime.datetime.strptime(raw_input, "%Y-%m-%dT%H:%M:%S")
-        date_with_tz = add_default_timezone(date)
+        # By default, we set the timezone to UTC+2 (Paris)... Until we expand worldwide!
+        date_with_tz = date.replace(tzinfo=datetime.timezone(datetime.timedelta(hours=2)))
         result = date_with_tz.isoformat()
     except ValueError:
         pass

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ extras_require = {"test": ["pytest"], "dev": []}
 
 setup(
     name="cleaning-scripts",
-    version="0.2.29",
+    version="0.2.30",
     author="Arkhn",
     author_email="contact@arkhn.org",
     description="Python scripts used in the FHIR integration pipeline "


### PR DESCRIPTION
Looks like the way the api is designed doesn't let us declare util functions at the top of the file.
Removed the function and waiting for the refacto.