### PR TITLE
Add priority script

### DIFF
--- a/scripts/custom/map_priority.py
+++ b/scripts/custom/map_priority.py
@@ -11,12 +11,12 @@ class Priority(Enum):
 def map_priority(raw_input):
     """Map int to ServiceRequest.priority (0: stat, 1: asap, 2: urgent, 3+ routine)"""
     mapping = {
-        0: Priority.STAT.value,
-        1: Priority.ASAP.value,
-        2: Priority.URGENT.value,
-        3: Priority.ROUTINE.value,
+        "0": Priority.STAT.value,
+        "1": Priority.ASAP.value,
+        "2": Priority.URGENT.value,
+        "3": Priority.ROUTINE.value,
     }
-    if raw_input in mapping.keys():
-        return mapping[raw_input]
+    if str(raw_input) in mapping.keys():
+        return mapping[str(raw_input)]
     else:
         return mapping[3]

--- a/scripts/custom/map_priority.py
+++ b/scripts/custom/map_priority.py
@@ -1,0 +1,22 @@
+from enum import Enum
+
+
+class Priority(Enum):
+    ROUTINE = "routine"
+    URGENT = "urgent"
+    ASAP = "asap"
+    STAT = "stat"
+
+
+def map_priority(raw_input):
+    """Map int to ServiceRequest.priority (0: stat, 1: asap, 2: urgent, 3+ routine)"""
+    mapping = {
+        0: Priority.STAT.value,
+        1: Priority.ASAP.value,
+        2: Priority.URGENT.value,
+        3: Priority.ROUTINE.value,
+    }
+    if raw_input in mapping.keys():
+        return mapping[raw_input]
+    else:
+        return mapping[3]

--- a/scripts/custom/map_priority.py
+++ b/scripts/custom/map_priority.py
@@ -19,4 +19,4 @@ def map_priority(raw_input):
     if str(raw_input) in mapping.keys():
         return mapping[str(raw_input)]
     else:
-        return mapping[3]
+        return mapping["3"]

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ extras_require = {"test": ["pytest"], "dev": []}
 
 setup(
     name="cleaning-scripts",
-    version="0.2.30",
+    version="0.2.31",
     author="Arkhn",
     author_email="contact@arkhn.org",
     description="Python scripts used in the FHIR integration pipeline "

--- a/tests/custom/test_map_priority.py
+++ b/tests/custom/test_map_priority.py
@@ -1,0 +1,44 @@
+from scripts import custom
+
+
+def test_map_priority():
+
+    raw_input_1 = "0"
+    output_1 = custom.map_priority(raw_input_1)
+    assert output_1 == "stat"
+
+    raw_input_2 = 0
+    output_2 = custom.map_priority(raw_input_2)
+    assert output_2 == "stat"
+
+    raw_input_3 = "1"
+    output_3 = custom.map_priority(raw_input_3)
+    assert output_3 == "asap"
+
+    raw_input_4 = 1
+    output_4 = custom.map_priority(raw_input_4)
+    assert output_4 == "asap"
+
+    raw_input_5 = "2"
+    output_5 = custom.map_priority(raw_input_5)
+    assert output_5 == "urgent"
+
+    raw_input_6 = 2
+    output_6 = custom.map_priority(raw_input_6)
+    assert output_6 == "urgent"
+
+    raw_input_7 = "50"
+    output_7 = custom.map_priority(raw_input_7)
+    assert output_7 == "routine"
+
+    raw_input_8 = 50
+    output_8 = custom.map_priority(raw_input_8)
+    assert output_8 == "routine"
+
+    raw_input_9 = "-1"
+    output_9 = custom.map_priority(raw_input_9)
+    assert output_9 == "routine"
+
+    raw_input_10 = -1
+    output_10 = custom.map_priority(raw_input_10)
+    assert output_10 == "routine"


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
For croissant environment, I have an int to indicate the priority of a servicerequest, and the valueset associated to ServiceRequest.priority is marked as `required` (https://www.hl7.org/fhir/valueset-request-priority.html).
A map has been created:
0 -> stat
1 -> asap
2 -> urgent
other -> routine